### PR TITLE
Update bin/ci to use gh CLI instead of hub CLI

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -1,7 +1,70 @@
 #!/bin/bash
-#/ Usage: `ci`
+#/ Usage: `ci [ref]`
 #/ Prints verbose CI status from GitHub, every 5 seconds, until it's passing.
 #/ Once complete, it will say "Your tests have all passed."
 
-wait_on hub ci-status -v "$@";
+ci_status() {
+  local ref="${1:-HEAD}"
+
+  # Try `gh pr checks` first (works for PRs and branches with PRs)
+  local pr_out pr_code
+  pr_out=$(gh pr checks "$ref" 2>&1)
+  pr_code=$?
+
+  if [ $pr_code -ne 1 ] || [[ ! "$pr_out" =~ "no pull requests found" ]]; then
+    echo "$pr_out"
+    if [ $pr_code -eq 8 ]; then
+      return 1
+    fi
+    return $pr_code
+  fi
+
+  # Fallback for arbitrary revisions without an open PR (e.g. main, commit SHAs)
+  local check_runs_json combined_status_json
+  check_runs_json=$(gh api "repos/{owner}/{repo}/commits/${ref}/check-runs" 2>/dev/null) || return 1
+  combined_status_json=$(gh api "repos/{owner}/{repo}/commits/${ref}/status" 2>/dev/null) || return 1
+
+  local pending_count=0
+  local fail_count=0
+  local total_count=0
+
+  while IFS=$'\t' read -r status conclusion name; do
+    [ -z "$name" ] && continue
+    total_count=$((total_count + 1))
+    if [ "$status" != "completed" ]; then
+      pending_count=$((pending_count + 1))
+      printf "%-12s %-12s %s\n" "$status" "${conclusion:-pending}" "$name"
+    else
+      if [ "$conclusion" = "failure" ] || [ "$conclusion" = "timed_out" ] || [ "$conclusion" = "action_required" ]; then
+        fail_count=$((fail_count + 1))
+      fi
+      printf "%-12s %-12s %s\n" "$status" "$conclusion" "$name"
+    fi
+  done < <(echo "$check_runs_json" | jq -r '.check_runs[]? | "\(.status)\t\(.conclusion // "")\t\(.name)"')
+
+  while IFS=$'\t' read -r state context; do
+    [ -z "$context" ] && continue
+    total_count=$((total_count + 1))
+    if [ "$state" = "pending" ]; then
+      pending_count=$((pending_count + 1))
+    elif [ "$state" = "error" ] || [ "$state" = "failure" ]; then
+      fail_count=$((fail_count + 1))
+    fi
+    printf "%-12s %-12s %s\n" "$state" "$state" "$context"
+  done < <(echo "$combined_status_json" | jq -r '.statuses[]? | "\(.state)\t\(.context)"')
+
+  if [ $total_count -eq 0 ]; then
+    echo "No checks or statuses found for $ref."
+    return 0
+  fi
+
+  if [ $pending_count -gt 0 ]; then
+    return 1
+  fi
+
+  return 0
+}
+
+export -f ci_status
+wait_on ci_status "$@"
 say -v Daniel "Your tests have all passed."

--- a/bin/ci
+++ b/bin/ci
@@ -15,14 +15,24 @@ ci_status() {
     echo "$pr_out"
     if [ $pr_code -eq 8 ]; then
       return 1
+    elif [ $pr_code -eq 0 ]; then
+      return 0
+    else
+      return 6
     fi
-    return $pr_code
   fi
 
   # Fallback for arbitrary revisions without an open PR (e.g. main, commit SHAs)
-  local check_runs_json combined_status_json
-  check_runs_json=$(gh api "repos/{owner}/{repo}/commits/${ref}/check-runs" 2>/dev/null) || return 1
-  combined_status_json=$(gh api "repos/{owner}/{repo}/commits/${ref}/status" 2>/dev/null) || return 1
+  local check_runs_json combined_status_json check_code status_code
+  check_runs_json=$(gh api "repos/{owner}/{repo}/commits/${ref}/check-runs" 2>/dev/null)
+  check_code=$?
+  combined_status_json=$(gh api "repos/{owner}/{repo}/commits/${ref}/status" 2>/dev/null)
+  status_code=$?
+
+  if [ $check_code -ne 0 ] || [ $status_code -ne 0 ]; then
+    echo "Error querying GitHub API for ref $ref." >&2
+    return 6
+  fi
 
   local pending_count=0
   local fail_count=0
@@ -35,7 +45,7 @@ ci_status() {
       pending_count=$((pending_count + 1))
       printf "%-12s %-12s %s\n" "$status" "${conclusion:-pending}" "$name"
     else
-      if [ "$conclusion" = "failure" ] || [ "$conclusion" = "timed_out" ] || [ "$conclusion" = "action_required" ]; then
+      if [ "$conclusion" != "success" ] && [ "$conclusion" != "neutral" ] && [ "$conclusion" != "skipped" ]; then
         fail_count=$((fail_count + 1))
       fi
       printf "%-12s %-12s %s\n" "$status" "$conclusion" "$name"
@@ -47,7 +57,7 @@ ci_status() {
     total_count=$((total_count + 1))
     if [ "$state" = "pending" ]; then
       pending_count=$((pending_count + 1))
-    elif [ "$state" = "error" ] || [ "$state" = "failure" ]; then
+    elif [ "$state" != "success" ]; then
       fail_count=$((fail_count + 1))
     fi
     printf "%-12s %-12s %s\n" "$state" "$state" "$context"
@@ -55,16 +65,23 @@ ci_status() {
 
   if [ $total_count -eq 0 ]; then
     echo "No checks or statuses found for $ref."
-    return 0
+    return 6
   fi
 
   if [ $pending_count -gt 0 ]; then
     return 1
   fi
 
+  if [ $fail_count -gt 0 ]; then
+    return 6
+  fi
+
   return 0
 }
 
 export -f ci_status
-wait_on ci_status "$@"
-say -v Daniel "Your tests have all passed."
+if wait_on ci_status "$@"; then
+  say -v Daniel "Your tests have all passed."
+else
+  exit 1
+fi

--- a/bin/wait_on
+++ b/bin/wait_on
@@ -5,7 +5,7 @@
 #/ halts and says to your speakers, "Task is done."
 
 while true; do
-    $@;
+    "$@";
     code=$?;
     test -n "$DEBUG" && echo "code=$code";
     if [ $code -gt 5 ] || [ $code -lt 1 ]; then
@@ -15,3 +15,4 @@ while true; do
     sleep 5;
 done;
 say -v Karen "Task is done."
+exit $code

--- a/osx/bashrc.d.symlink/10_env.sh
+++ b/osx/bashrc.d.symlink/10_env.sh
@@ -4,23 +4,40 @@ if [ -d "/opt/homebrew" ] && [ ! -f "/usr/local/bin/brew" ]; then
 fi
 
 add_to_path() {
-  if [ -d "$1" ]; then
-    PATH="$1:$PATH"
+  # Only add if it's a directory and NOT already in PATH
+  if [ -d "$1" ] && [[ ":$PATH:" != *":$1:"* ]]; then
+    # If PATH is empty, just set it. Otherwise, prepend with a colon.
+    PATH="$1${PATH:+:$PATH}"
   fi
 }
 
-PATH="/usr/bin:/bin:/usr/sbin:/sbin"
-PATH="/usr/local/bin:/usr/local/sbin:$PATH"
+# Base system paths (added in reverse priority order since add_to_path prepends)
+add_to_path "/sbin"
+add_to_path "/usr/sbin"
+add_to_path "/bin"
+add_to_path "/usr/bin"
+
+# Local user paths
+add_to_path "/usr/local/sbin"
+add_to_path "/usr/local/bin"
+
+# Go, Java, Dotfiles, etc.
 add_to_path "/usr/local/opt/go/libexec/bin"
 add_to_path "$HOME/.dotfiles/bin"
 add_to_path "$HOME/dotfiles/bin"
 add_to_path "$HOME/.bin"
 add_to_path "$HOME/bin"
 add_to_path "$HOME/.local/bin"
-[[ -d "/usr/local/opt/openjdk/bin" ]] && add_to_path "/usr/local/opt/openjdk/bin"
-[[ -d "$HOME/go" ]]  && PATH="$HOME/go/bin:$PATH" && export GOPATH="$HOME/go"
-[[ -d "$HOME/.cargo/bin" ]] && PATH="$HOME/.cargo/bin:$PATH"
-[[ -n "${HOMEBREW_PREFIX}" ]] && PATH="$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:$PATH"
+add_to_path "/usr/local/opt/openjdk/bin"
+
+[[ -d "$HOME/go" ]] && add_to_path "$HOME/go/bin" && export GOPATH="$HOME/go"
+
+add_to_path "$HOME/.cargo/bin"
+
+if [[ -n "${HOMEBREW_PREFIX}" ]]; then
+  add_to_path "$HOMEBREW_PREFIX/sbin"
+  add_to_path "$HOMEBREW_PREFIX/bin"
+fi
 
 for pkg in $HOME/.dotfiles/pkg/*; do
   add_to_path "$pkg/bin"


### PR DESCRIPTION
Replaces `hub ci-status` in `bin/ci` with `gh` CLI commands. Supports both pull requests and arbitrary git revisions (e.g. `main`, commit SHAs, or branches without an open PR).